### PR TITLE
Large error support update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/index.js
+++ b/index.js
@@ -37,21 +37,19 @@ module.exports = async function errorHandling(client, config) {
             .addFields([
               {
                 name: "__Event Type__",
-                value: `\`${eventType || "No types provided."}\``,
+                value: `\`${eventType.slice(0, 1023) || "No types provided."}\``,
                 inline: true,
               },
               {
                 name: "__Message__",
                 value: `**\`${
-                  additionalInfo || "No Additional Info Provided"
+                  additionalInfo.slice(0, 1023) || "No Additional Info Provided"
                 }\`**`,
                 inline: true,
-              },
-              {
-                name: "__Detailed__",
-                value: `\`\`\`${errorMessage || "Nothing found here."}\`\`\``,
-              },
-            ]),
+              }
+            ])
+            .setDescription(`"__Detailed__"\n\`\`\`${errorMessage.slice(0, 4095) || "Nothing found here."}\`\`\``)
+            ,
         ],
       });
     } catch (error) {
@@ -166,7 +164,6 @@ module.exports = async function errorHandling(client, config) {
     const paddedError =
       " ".repeat(2) + colors.gray(errorMessage) + " ".repeat(paddingLength);
     const paddedOrigin = colors.red(origin) + " ".repeat(paddingLength);
-    const timestampLine = " ".repeat(2) + timestamp + " ".repeat(2);
 
     console.error(topBorder);
     console.error(

--- a/index.js
+++ b/index.js
@@ -48,12 +48,12 @@ module.exports = async function errorHandling(client, config) {
                 inline: true,
               }
             ])
-            .setDescription(`"__Detailed__"\n\`\`\`${errorMessage.slice(0, 4074) || "Nothing found here."}\`\`\``)
+            .setDescription(`__Detailed__\n\`\`\`${errorMessage.slice(0, 4076) || "Nothing found here."}\`\`\``)
           ,
         ],
       });
 
-      if (errorMessage.length > 4074) {
+      if (errorMessage.length > 4076) {
         await webhook.send({
           username: embedConfig.webhookUsername,
           avatarURL: embedConfig.embedAvatarUrl,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { WebhookClient, EmbedBuilder } = require("discord.js");
+const { WebhookClient, EmbedBuilder, AttachmentBuilder } = require("discord.js");
 const colors = require("colors");
 
 module.exports = async function errorHandling(client, config) {
@@ -24,6 +24,7 @@ module.exports = async function errorHandling(client, config) {
   const sendErrorMessage = async (error, eventType, additionalInfo = "") => {
     try {
       let errorMessage = error instanceof Error ? error.stack : String(error);
+
       await webhook.send({
         username: embedConfig.webhookUsername,
         avatarURL: embedConfig.embedAvatarUrl,
@@ -37,21 +38,33 @@ module.exports = async function errorHandling(client, config) {
             .addFields([
               {
                 name: "__Event Type__",
-                value: `\`${eventType.slice(0, 1023) || "No types provided."}\``,
+                value: `\`${eventType.slice(0, 1021) || "No types provided."}\``,
                 inline: true,
               },
               {
                 name: "__Message__",
-                value: `**\`${
-                  additionalInfo.slice(0, 1023) || "No Additional Info Provided"
-                }\`**`,
+                value: `**\`${additionalInfo.slice(0, 1017) || "No Additional Info Provided"
+                  }\`**`,
                 inline: true,
               }
             ])
-            .setDescription(`"__Detailed__"\n\`\`\`${errorMessage.slice(0, 4095) || "Nothing found here."}\`\`\``)
-            ,
+            .setDescription(`"__Detailed__"\n\`\`\`${errorMessage.slice(0, 4074) || "Nothing found here."}\`\`\``)
+          ,
         ],
       });
+
+      if (errorMessage.length > 4095) {
+        await webhook.send({
+          username: embedConfig.webhookUsername,
+          avatarURL: embedConfig.embedAvatarUrl,
+          files: [
+            new AttachmentBuilder()
+              .setName("error.txt")
+              .setFile(Buffer.from(errorMessage, "utf-8"))
+              .setSpoiler(false)
+          ]
+        });
+      }
     } catch (error) {
       console.error(colors.bgRed("Error sending error message:"), error);
     }
@@ -174,10 +187,10 @@ module.exports = async function errorHandling(client, config) {
     if (details) {
       console.error(
         vertical +
-          " ".repeat(2) +
-          colors.red.bold(details) +
-          " ".repeat(paddingLength) +
-          vertical
+        " ".repeat(2) +
+        colors.red.bold(details) +
+        " ".repeat(paddingLength) +
+        vertical
       );
     }
     console.error(bottomBorder);
@@ -208,17 +221,17 @@ module.exports = async function errorHandling(client, config) {
     console.warn(topBorder);
     console.warn(
       vertical +
-        colors.bgYellow.black.bold(` WARNING `) +
-        colors.yellow(` [${timestamp}] `)
+      colors.bgYellow.black.bold(` WARNING `) +
+      colors.yellow(` [${timestamp}] `)
     );
     console.warn(vertical + colors.yellow.bold(paddedWarning) + vertical);
     if (details) {
       console.warn(
         vertical +
-          " ".repeat(2) +
-          colors.yellow.bold(details) +
-          " ".repeat(paddingLength) +
-          vertical
+        " ".repeat(2) +
+        colors.yellow.bold(details) +
+        " ".repeat(paddingLength) +
+        vertical
       );
     }
     console.warn(vertical + colors.yellow.bold(timestampLine) + vertical);

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = async function errorHandling(client, config) {
         ],
       });
 
-      if (errorMessage.length > 4095) {
+      if (errorMessage.length > 4074) {
         await webhook.send({
           username: embedConfig.webhookUsername,
           avatarURL: embedConfig.embedAvatarUrl,


### PR DESCRIPTION
Hello, I had problems before because when I received errors of more than 1024 characters the webhook was not sent by limitations of Discord, so I decided to send a correction that can help in this, in this small update I made that the detailed error is in the description increasing its capacity to 4075 characters, edit so that if the error is very long even so the embed is sent with the maximum possible characters, and also send an attached file with the complete error in case you want to read it or for the purpose that the user needs. (I also deleted a line of code that is not used, but this is the least of it). 

Attached are screenshots of what it looks like: 

![image](https://github.com/Alpha5959/discord.js-anticrash/assets/67084442/c455e108-2518-4375-9e7b-9ba9daf9421f)
![image](https://github.com/Alpha5959/discord.js-anticrash/assets/67084442/78d46e0f-6b60-498c-a4f5-b5d6de6a1eb5)
